### PR TITLE
Add option to pass version name from cli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id 'net.researchgate.release' version '2.6.0'
 }
 
-ext.ballerinaLangVersion = project.ballerinaVersion
+ext.ballerinaLangVersion = project.version
 ext.ballerinaSourceDirectory = "$buildDir/../src/main/ballerina"
 ext.commonsCodecVersion = "1.12"
 ext.commonIoVersion = "2.6"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,11 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
-version=1.3.0-SNAPSHOT
-ballerinaVersion=1.3.0-SNAPSHOT
 group=org.ballerinax.docker
+
+
+if (project.hasProperty('version')) {
+    version=project.version
+} else {
+    version=1.3.0-SNAPSHOT
+}


### PR DESCRIPTION
## Purpose
> As a part of ballerina release process automation, with this PR the project version can be passed as a cli argument. This way we can automate the version bumping.