### PR TITLE
Allow empty/undefined environment variables

### DIFF
--- a/docker-extension/src/main/java/org/ballerinax/docker/utils/DockerPluginUtils.java
+++ b/docker-extension/src/main/java/org/ballerinax/docker/utils/DockerPluginUtils.java
@@ -117,15 +117,13 @@ public class DockerPluginUtils {
      * @param value variable value
      * @return Resolved variable
      */
-    public static String resolveValue(String value) throws DockerPluginException {
+    public static String resolveValue(String value) {
         int startIndex;
         if ((startIndex = value.indexOf("$env{")) >= 0) {
             int endIndex = value.indexOf("}", startIndex);
             if (endIndex > 0) {
                 String varName = value.substring(startIndex + 5, endIndex).trim();
-                String resolvedVar = Optional.ofNullable(System.getenv(varName)).orElseThrow(() ->
-                        new DockerPluginException("error resolving value: " + varName +
-                                " is not set in the environment."));
+                String resolvedVar = Optional.ofNullable(System.getenv(varName));
                 String rest = (value.length() > endIndex + 1) ? resolveValue(value.substring(endIndex + 1)) : "";
                 return value.substring(0, startIndex) + resolvedVar + rest;
             }

--- a/docker-extension/src/test/java/org/ballerinax/docker/utils/DockerPluginUtilsTest.java
+++ b/docker-extension/src/test/java/org/ballerinax/docker/utils/DockerPluginUtilsTest.java
@@ -67,6 +67,7 @@ public class DockerPluginUtilsTest {
     public void resolveValueTest() throws Exception {
         Map<String, String> env = new HashMap<>();
         env.put("DOCKER_USERNAME", "anuruddhal");
+        env.put("DOCKER_PASSWORD", "");
         setEnv(env);
         try {
             Assert.assertEquals(DockerPluginUtils.resolveValue("$env{DOCKER_USERNAME}"), "anuruddhal");
@@ -74,14 +75,12 @@ public class DockerPluginUtilsTest {
             Assert.fail("Unable to resolve environment variable");
         }
         try {
-            DockerPluginUtils.resolveValue("$env{DOCKER_PASSWORD}");
-            Assert.fail("Env value should be resolved");
+            Assert.assertEquals(DockerPluginUtils.resolveValue("$env{DOCKER_PASSWORD}"), "");
+            Assert.assertEquals(DockerPluginUtils.resolveValue("$env{DOCKER_UNDEFINED}"), "");
         } catch (DockerPluginException e) {
-            Assert.assertEquals(e.getMessage(), "error resolving value: DOCKER_PASSWORD is not set in the " +
-                    "environment.");
+            Assert.fail("Unable to resolve null/blank environment variable");
         }
         Assert.assertEquals(DockerPluginUtils.resolveValue("demo"), "demo");
-
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Allow empty/undefined environment variables when running the build.

This allows more flexibility for build environments without having to define variables that are not needed or throw a `DockerPluginException` if the value is null in the current environment.

## Goals
Avoid users having to specify all environment variables for DOCKER_USERNAME / DOCKER_PASSWORD / DOCKER_XXX when building locally but still use the environment variables when building in CICD.

## Approach
Remove throwing `DockerPluginException` and just set value to be "". See commit log for more details.