### PR TITLE
Revert "Bump docker java version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,7 +285,7 @@
         <com.fasterxml.jackson.dataformat.yaml.version>2.9.8</com.fasterxml.jackson.dataformat.yaml.version>
         <commons.codec.version>1.15</commons.codec.version>
         <commons.io.version>2.11.0</commons.io.version>
-        <docker.java.version>3.2.13</docker.java.version>
+        <docker.java.version>3.1.5</docker.java.version>
         <jackson.version>2.9.8</jackson.version>
         <maven.jacoco.plugin.version>0.8.3</maven.jacoco.plugin.version>
         <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerina-docker#968
As it contains breaking changes. We can go ahead with older versions as per https://github.com/wso2-enterprise/internal-support-ballerina/issues/188#issuecomment-1261744928