### PR TITLE
fix LS crashing in devcontainers

### DIFF
--- a/base/devcontainer/Dockerfile
+++ b/base/devcontainer/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu21.04
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian12
 LABEL maintainer="dev@ballerina.io"
 
 # Ballerina deb installer filename.


### PR DESCRIPTION
## Purpose
> When starting up the devcontainer using the given image, language server keeps crashing. With this change, it will be fixed

## Goals
> Instead of using ubuntu base image, this fix will use debian based image.

## Approach
> Changed the base image type from ubuntu to debian12.