### PR TITLE
Bump jdk version to jdk-21.0.10

### DIFF
--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM alpine:3.20.3
+FROM alpine:3.20.9
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -38,12 +38,12 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
       amd64|x86_64) \
-          ESUM='8da7da49101d45f646272616f20e8b10d57472bbf5961d64ffb07d7ba93c6909'; \
-          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.5_11.tar.gz'; \
+          ESUM='8eb39f442c3c603e414af43844b419a9b5d4f3fe221181f323aa4eec1bd20cf8'; \
+          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.10_7.tar.gz'; \
          ;; \
       aarch64) \
-          ESUM='f22e32b869dd0e5e3f248646f62bffaa307b360299488ac8764e622923d7e747'; \
-          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.5_11.tar.gz'; \
+          ESUM='19eba6c3877612157ef1f46deb92745b4567cfcd64b79f15449c68cd2b7501e3'; \
+          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.10_7.tar.gz'; \
         ;;\
       *) \
          echo "Unsupported arch: ${ARCH}"; \


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the OpenJDK version used in the Docker base image from jdk-21.0.5 to jdk-21.0.10. The update includes revised checksums and download URLs for both the amd64 and aarch64 architectures to ensure compatibility and integrity verification across supported platforms.

## Changes

- **File Modified**: `base/docker/Dockerfile`
- **Impact**: Updated OpenJDK download artifacts for two architectures (amd64/x86_64 and aarch64) with new version-specific checksums and binary URLs
- **Lines Changed**: 4 additions, 4 deletions

## Review Effort

Low - The changes are confined to version pinning constants with no modifications to the build logic or control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->