### PR TITLE
Update Alpine and JRE version

### DIFF
--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------
 
-FROM alpine:3.20.9
+FROM alpine:3.21.3
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
@@ -37,13 +37,13 @@ RUN mkdir -p /ballerina/files \
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
-      amd64|x86_64) \
-          ESUM='8eb39f442c3c603e414af43844b419a9b5d4f3fe221181f323aa4eec1bd20cf8'; \
-          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.10_7.tar.gz'; \
+       amd64|x86_64) \
+         ESUM='c52d7063c2709e4db1f66b6f9900f09398f0b5f6d7e5c5939cc6ed1ce0be23cd'; \
+         BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
          ;; \
-      aarch64) \
-          ESUM='19eba6c3877612157ef1f46deb92745b4567cfcd64b79f15449c68cd2b7501e3'; \
-          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.10%2B7/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.10_7.tar.gz'; \
+       aarch64) \
+         ESUM='7e5a4aca6b43483e5b7ec82a3b1f7bca33cc0fc6e3b8a4b5e3c3e3b8e3b8e3b8'; \
+         BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
         ;;\
       *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/base/docker/Dockerfile
+++ b/base/docker/Dockerfile
@@ -38,11 +38,11 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        amd64|x86_64) \
-         ESUM='c52d7063c2709e4db1f66b6f9900f09398f0b5f6d7e5c5939cc6ed1ce0be23cd'; \
+         ESUM='38bfdcef1e4b45de2ec222047ac79c76bea75d4d7406a310e26cfa236763f05f'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
          ;; \
        aarch64) \
-         ESUM='7e5a4aca6b43483e5b7ec82a3b1f7bca33cc0fc6e3b8a4b5e3c3e3b8e3b8e3b8'; \
+         ESUM='c8d63598d1dc0a656033515ed258bd6db37506a05407d9f65cd23b95c21027b5'; \
          BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.11_10.tar.gz'; \
         ;;\
       *) \


### PR DESCRIPTION
## Purpose
> Update Alpine and JRE version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request updates Docker base images and OpenJDK runtimes used by the project to newer releases to keep dependency handling current and maintain compatibility.

- base/docker/Dockerfile
  - Upgrades the Alpine base image from 3.20.9 to 3.21.3.
  - Updates the Temurin OpenJDK 21 runtime reference to 21.0.11+10 (per-architecture download URLs and SHA256 checksums), with existing extraction and installation flow preserved.

- base/base-image/Dockerfile
  - Updates SHA256 checksum values used to verify the downloaded Temurin OpenJDK 17 JRE tarballs for supported architectures (download URLs and extraction logic remain unchanged).
  - Keeps the existing Alpine base (alpine:3.17.3) and the current Dockerfile structure.

No public or exported code interfaces were changed. The changes are intended to improve dependency currency and maintainability while preserving existing image build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->